### PR TITLE
빌드시 github 설정을 제외시켜라

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -181,6 +181,7 @@ exclude:
   - Rakefile
   - README
   - tmp
+  - .github
 keep_files:
   - .git
   - .svn


### PR DESCRIPTION
워크 플로우 설정은 `master` 브랜치에 배포될 필요가 없다