### PR TITLE
Github Actions 워크 플로우를 보강하라

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: 
       - work
+      - work-test
 jobs:
   build:
     name: blog-auto-publish
@@ -22,14 +23,14 @@ jobs:
       
       - uses: actions/cache@v1
         with:
-          path: vendor/bundle
+          path: ../vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gems
       
       - name: Bundle install
         run: |
-          bundle config path vendor/bundle
+          bundle config path ../vendor/bundle
           bundle install --jobs 4 --retry 3
       
       - name: jekyll build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: 
       - work
-      - work-test
+      - work-flow-cache-test
 jobs:
   build:
     name: blog-auto-publish
@@ -23,14 +23,14 @@ jobs:
       
       - uses: actions/cache@v1
         with:
-          path: ../vendor/bundle
+          path: ~/vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gems
       
       - name: Bundle install
         run: |
-          bundle config path ../vendor/bundle
+          bundle config path ~/vendor/bundle
           bundle install --jobs 4 --retry 3
       
       - name: jekyll build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: 
       - work
-      - work-flow-cache-test
 jobs:
   build:
     name: blog-auto-publish


### PR DESCRIPTION
## 루비 모듈 의존성을 캐싱하지 못하여 빌드 속도가 오래걸리는 문제를 해결하라

### 문제의 원인
캐시경로가 상대경로로 잡혀있음